### PR TITLE
Fix mask dimension handling

### DIFF
--- a/func_3d/function.py
+++ b/func_3d/function.py
@@ -107,7 +107,7 @@ def train_sam(args, net: nn.Module, optimizer1, optimizer2, train_loader,
                                     inference_state=train_state,
                                     frame_idx=id,
                                     obj_id=ann_obj_id,
-                                    mask=gt_mask.squeeze(0),
+                                    mask=gt_mask.squeeze(),
                                 )
                             elif prompt == 'click':
                                 points = pt_dict[id][ann_obj_id].to(device=GPUdevice)
@@ -257,7 +257,7 @@ def validation_sam(args, val_loader, epoch, net: nn.Module, clean_dir=True):
                                     inference_state=train_state,
                                     frame_idx=id,
                                     obj_id=ann_obj_id,
-                                    mask=gt_mask.squeeze(0),
+                                    mask=gt_mask.squeeze(),
                                 )
                             elif prompt == 'click':
                                 points = pt_dict[id][ann_obj_id].to(device=GPUdevice)

--- a/sam2_train/modeling/spg_prompt_encoder.py
+++ b/sam2_train/modeling/spg_prompt_encoder.py
@@ -14,24 +14,58 @@ class SPGPromptEncoder(nn.Module):
             mask_in_chans=mask_in_chans,
         )
 
-    def forward(self, image, mirrored_image):
-        """Generate prompt embeddings from image and its mirrored counterpart."""
-        diff = (image - mirrored_image).abs().mean(1, keepdim=True)
-        thresh = diff.mean(dim=(2, 3), keepdim=True) + diff.std(dim=(2, 3), keepdim=True)
-        mask = (diff > thresh).float()
-        B, _, H, W = mask.shape
-        coords = torch.zeros(B, 1, 2, device=image.device)
-        labels = torch.ones(B, 1, dtype=torch.int32, device=image.device)
-        for i in range(B):
-            loc = torch.nonzero(mask[i, 0], as_tuple=False)
-            if loc.numel() > 0:
-                center = loc.float().mean(0)
-                coords[i, 0, 0] = center[1]
-                coords[i, 0, 1] = center[0]
-            else:
-                coords[i, 0] = torch.tensor([W / 2, H / 2], device=image.device)
-        sparse, dense = self.prompt_encoder(points=(coords, labels), boxes=None, masks=mask)
-        return sparse, dense
+    @property
+    def mask_input_size(self):
+        """Size of masks expected by the underlying prompt encoder."""
+        return self.prompt_encoder.mask_input_size
+
+    def forward(
+        self,
+        image=None,
+        mirrored_image=None,
+        *,
+        points=None,
+        boxes=None,
+        masks=None,
+        batch_size=-1,
+    ):
+        """Generate prompt embeddings.
+
+        If ``image`` and ``mirrored_image`` are provided, embeddings are
+        produced based on the difference between the images (self‑prompt
+        generation). Otherwise this method proxies to the underlying
+        ``PromptEncoder`` so it can be used transparently anywhere a regular
+        ``PromptEncoder`` would be expected.
+        """
+
+        if image is not None and mirrored_image is not None:
+            diff = (image - mirrored_image).abs().mean(1, keepdim=True)
+            thresh = diff.mean(dim=(2, 3), keepdim=True) + diff.std(dim=(2, 3), keepdim=True)
+            mask = (diff > thresh).float()
+            B, _, H, W = mask.shape
+            coords = torch.zeros(B, 1, 2, device=image.device)
+            labels = torch.ones(B, 1, dtype=torch.int32, device=image.device)
+            for i in range(B):
+                loc = torch.nonzero(mask[i, 0], as_tuple=False)
+                if loc.numel() > 0:
+                    center = loc.float().mean(0)
+                    coords[i, 0, 0] = center[1]
+                    coords[i, 0, 1] = center[0]
+                else:
+                    coords[i, 0] = torch.tensor([W / 2, H / 2], device=image.device)
+            return self.prompt_encoder(
+                points=(coords, labels),
+                boxes=None,
+                masks=mask,
+                batch_size=batch_size,
+            )
+
+        return self.prompt_encoder(
+            points=points,
+            boxes=boxes,
+            masks=masks,
+            batch_size=batch_size,
+        )
 
     def get_dense_pe(self):
         return self.prompt_encoder.get_dense_pe()


### PR DESCRIPTION
## Summary
- ensure newly added masks drop any singleton dimension before training or validation
- expose `mask_input_size` in self-prompt generator for SAM2 compatibility
- allow `SPGPromptEncoder` to handle regular prompt-encoder arguments when self-prompt images are not provided

## Testing
- `python -m py_compile func_3d/function.py sam2_train/modeling/spg_prompt_encoder.py`


------
https://chatgpt.com/codex/tasks/task_b_6867aed07bb4832d971e56dff63bf149