### PR TITLE
Fix use_spg handling in validation

### DIFF
--- a/func_3d/function.py
+++ b/func_3d/function.py
@@ -217,6 +217,8 @@ def validation_sam(args, val_loader, epoch, net: nn.Module, clean_dir=True):
     threshold = (0.1, 0.3, 0.5, 0.7, 0.9)
     prompt_freq = args.prompt_freq
 
+    use_spg = getattr(args, "use_spg", False)
+
     lossfunc = criterion_G
     # lossfunc = paper_loss
 


### PR DESCRIPTION
## Summary
- add local `use_spg` variable at the start of `validation_sam`

## Testing
- `python -m py_compile func_3d/function.py`

------
https://chatgpt.com/codex/tasks/task_b_6867bb411738832d8ab33e048bccb71a