### PR TITLE
Fix mask decoder tensor size mismatch

### DIFF
--- a/sam2_train/sam2_hiera_s.yaml
+++ b/sam2_train/sam2_hiera_s.yaml
@@ -86,6 +86,7 @@ model:
 
   num_maskmem: 7
   image_size: 1024
+  backbone_stride: 32
   # apply scaled sigmoid on mask logits for memory encoder, and directly feed input mask as output mask
   sigmoid_scale_for_mem_enc: 20.0
   sigmoid_bias_for_mem_enc: -10.0

--- a/sam2_train/sam2_hiera_t.yaml
+++ b/sam2_train/sam2_hiera_t.yaml
@@ -86,6 +86,7 @@ model:
 
   num_maskmem: 7
   image_size: 1024
+  backbone_stride: 32
   # apply scaled sigmoid on mask logits for memory encoder, and directly feed input mask as output mask
   # SAM decoder
   sigmoid_scale_for_mem_enc: 20.0


### PR DESCRIPTION
## Summary
- set `backbone_stride` to match memory attention output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6867be35381c832dbfa526d33d014858