### PR TITLE
Fix stride mismatch

### DIFF
--- a/sam2_train/sam2_hiera_s.yaml
+++ b/sam2_train/sam2_hiera_s.yaml
@@ -86,7 +86,8 @@ model:
 
   num_maskmem: 7
   image_size: 1024
-  backbone_stride: 32
+  # match the stride of the features returned by the image encoder
+  backbone_stride: 16
   # apply scaled sigmoid on mask logits for memory encoder, and directly feed input mask as output mask
   sigmoid_scale_for_mem_enc: 20.0
   sigmoid_bias_for_mem_enc: -10.0

--- a/sam2_train/sam2_hiera_t.yaml
+++ b/sam2_train/sam2_hiera_t.yaml
@@ -86,7 +86,8 @@ model:
 
   num_maskmem: 7
   image_size: 1024
-  backbone_stride: 32
+  # match the stride of the features returned by the image encoder
+  backbone_stride: 16
   # apply scaled sigmoid on mask logits for memory encoder, and directly feed input mask as output mask
   # SAM decoder
   sigmoid_scale_for_mem_enc: 20.0

--- a/train_3d.py
+++ b/train_3d.py
@@ -26,6 +26,8 @@ def main():
 
     net = get_network(args, args.net, use_gpu=args.gpu, gpu_device=GPUdevice, distribution = args.distributed)
     net.to(dtype=torch.bfloat16)
+    # Ensure the dataloader uses the same image size as the model
+    args.image_size = getattr(net, "image_size", args.image_size)
     if args.pretrain:
         print(args.pretrain)
         weights = torch.load(args.pretrain)


### PR DESCRIPTION
## Summary
- align `backbone_stride` with image encoder output resolution

## Testing
- `python -m py_compile train_3d.py`


------
https://chatgpt.com/codex/tasks/task_b_686ba161b87c832d99b560b1bb0674e9